### PR TITLE
Add to the sakila example db

### DIFF
--- a/src/main/kotlin/byos/WhereCondition.kt
+++ b/src/main/kotlin/byos/WhereCondition.kt
@@ -61,6 +61,10 @@ object WhereCondition {
                 DSL.selectOne().from(FILM_CATEGORY).where(left.CATEGORY_ID.eq(FILM_CATEGORY.CATEGORY_ID).and(FILM_CATEGORY.FILM_ID.eq(right.FILM_ID)))
             )
 
+            relationshipName == "parent_category" && left is Category && right is Category -> left.PARENT_CATEGORY_ID.eq(right.CATEGORY_ID)
+
+            relationshipName == "subcategories" && left is Category && right is Category -> left.CATEGORY_ID.eq(right.PARENT_CATEGORY_ID)
+
             else -> error("No relationship called $relationshipName found for tables $left and $right")
         }
 

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -79,6 +79,7 @@ type Language {
 type Inventory {
     inventory_id: ID!
     film: Film!
+    # example where a intermediate type should be visible to the client
     # stock: Int!
 }
 
@@ -97,8 +98,8 @@ type Category {
     category_id: ID!
     name: String!
     films(first: Int, after: String, orderBy: OrderFilmsBy): FilmConnection!
-    # parent: Category
-    # children: [Category!]!
+    parent_category: Category
+    subcategories: CategoryConnection!
 }
 
 type CategoryConnection {

--- a/src/test/kotlin/byos/ByosApplicationTest.kt
+++ b/src/test/kotlin/byos/ByosApplicationTest.kt
@@ -191,10 +191,88 @@ internal class ByosApplicationTest {
 
     @Test
     fun queryWithSelfRelation() {
-        TODO("Add self relation to database")
         val query = """
+            {
+              allCategories(first: 3) {
+                edges {
+                  node {
+                    name
+                    parent_category {
+                      name
+                    }
+                    subcategories {
+                      edges {
+                        node {
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
             """.trimIndent()
         val expectedResult = """
+            {
+              "data": {
+                "allCategories": {
+                  "edges": [
+                    {
+                      "node": {
+                        "name": "Action",
+                        "parent_category": null,
+                        "subcategories": {
+                          "edges": [
+                            {
+                              "node": {
+                                "name": "Sci-Fi"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "node": {
+                        "name": "Animation",
+                        "parent_category": null,
+                        "subcategories": {
+                          "edges": [
+                            {
+                              "node": {
+                                "name": "Children"
+                              }
+                            },
+                            {
+                              "node": {
+                                "name": "Classics"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "node": {
+                        "name": "Children",
+                        "parent_category": {
+                          "name": "Animation"
+                        },
+                        "subcategories": {
+                          "edges": [
+                            {
+                              "node": {
+                                "name": "Family"
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
             """.trimIndent()
         assertJsonEquals(expectedResult, graphQLService.executeGraphQLQuery(query))
     }


### PR DESCRIPTION
Addition to [Sakila](https://github.com/jOOQ/sakila/tree/main/postgres-sakila-db):
```SQL
ALTER TABLE category ADD COLUMN parent_category_id integer;
```
```SQL
ALTER TABLE category ADD CONSTRAINT fk_category_parent_category
  FOREIGN KEY (parent_category_id) REFERENCES category (category_id);
```
```SQL
-- Assign parent category IDs to establish relationships
UPDATE category
SET parent_category_id = CASE
    WHEN category_id = 3 THEN 2  -- Children is a subcategory of Animation
    WHEN category_id = 4 THEN 2  -- Classics is a subcategory of Animation
    WHEN category_id = 8 THEN 3  -- Family is a subcategory of Children
    WHEN category_id = 14 THEN 1 -- Sci-Fi is a subcategory of Action
    -- Add more update statements for other relationships as needed
    ELSE NULL  -- Set NULL for categories without a parent
  END;
```