### PR TITLE
Use all fields as cursor/sorting criteria if no pk exists

### DIFF
--- a/src/main/kotlin/byos/QueryTranspiler.kt
+++ b/src/main/kotlin/byos/QueryTranspiler.kt
@@ -154,7 +154,7 @@ class QueryTranspiler(
                 outerTable.field(it.name.lowercase())!! to
                         (it.value as EnumValue).name
             }.orEmpty()
-        val primaryKeyFields = outerTable.primaryKey?.fields?.map { outerTable.field(it)!! }.orEmpty()
+        val primaryKeyFields = outerTable.primaryKey?.fields?.map { outerTable.field(it)!! } ?: outerTable.fields().toList()
 
         val orderByFields = providedOrderCriteria.keys + (primaryKeyFields - providedOrderCriteria.keys).toSet()
         val orderByFieldsWithDirection = orderByFields


### PR DESCRIPTION
Provides deterministic order if no PK exists (for views!)